### PR TITLE
Added WhiteList and BlackList to prevent previewing real binary files

### DIFF
--- a/QuickLookStephenProject/GeneratePreviewForURL.m
+++ b/QuickLookStephenProject/GeneratePreviewForURL.m
@@ -3,6 +3,8 @@
 #include <QuickLook/QuickLook.h>
 #import <Foundation/Foundation.h>
 
+#import "URLChecker.h"
+
 // Generate a preview for the document with the given url
 OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview, 
                                CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options)
@@ -10,6 +12,10 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
     if (QLPreviewRequestIsCancelled(preview))
         return noErr;
     
+	CFBundleRef bundle = QLPreviewRequestGetGeneratorBundle(preview);
+	if (!shouldProcessItem(url, bundle))
+		return noErr;
+
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     
     NSMutableDictionary *props = [[NSMutableDictionary alloc] init];

--- a/QuickLookStephenProject/QLStephenDirectoriesBlackList.plist
+++ b/QuickLookStephenProject/QLStephenDirectoriesBlackList.plist
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<string>bin</string>
+</array>
+</plist>

--- a/QuickLookStephenProject/QLStephenExtensionsBlackList.plist
+++ b/QuickLookStephenProject/QLStephenExtensionsBlackList.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<string>lib</string>
+	<string>dll</string>
+	<string>a</string>
+	<string>o</string>
+	<string>dmg</string>
+	<string>zip</string>
+	<string>rar</string>
+	<string>tar</string>
+	<string>tgz</string>
+	<string>gz</string>
+	<string>tbz</string>
+	<string>bz2</string>
+	<string>taz</string>
+	<string>z</string>
+	<string>tlz</string>
+	<string>lz</string>
+	<string>txz</string>
+	<string>xz</string>
+	<string>gzip</string>
+</array>
+</plist>

--- a/QuickLookStephenProject/QLStephenWhiteList.plist
+++ b/QuickLookStephenProject/QLStephenWhiteList.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<string>README</string>
+	<string>CHANGELOG</string>
+	<string>INSTALL</string>
+	<string>CONFIGURE</string>
+	<string>THANKS</string>
+	<string>CapFile</string>
+</array>
+</plist>

--- a/QuickLookStephenProject/QuickLookStephen.xcodeproj/project.pbxproj
+++ b/QuickLookStephenProject/QuickLookStephen.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		2C05A19C06CAA52B00D84F6F /* GeneratePreviewForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C05A19B06CAA52B00D84F6F /* GeneratePreviewForURL.m */; };
+		4F98DDDF156E04F500C17A7F /* URLChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F98DDDD156E04F500C17A7F /* URLChecker.h */; };
+		4F98DDE0156E04F500C17A7F /* URLChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F98DDDE156E04F500C17A7F /* URLChecker.m */; };
+		4F98DDE3156E0C9F00C17A7F /* QLStephenWhiteList.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4F98DDE2156E0C9F00C17A7F /* QLStephenWhiteList.plist */; };
+		4F98DDE5156E0CB500C17A7F /* QLStephenExtensionsBlackList.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4F98DDE4156E0CB500C17A7F /* QLStephenExtensionsBlackList.plist */; };
+		4F98DDE7156E0F0A00C17A7F /* QLStephenDirectoriesBlackList.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4F98DDE6156E0F0A00C17A7F /* QLStephenDirectoriesBlackList.plist */; };
 		61E3BCFB0870B4F2002186A0 /* GenerateThumbnailForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E3BCFA0870B4F2002186A0 /* GenerateThumbnailForURL.m */; };
 		8D576312048677EA00EA77CD /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 08FB77B6FE84183AC02AAC07 /* main.c */; settings = {ATTRIBUTES = (); }; };
 		8D576314048677EA00EA77CD /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AA1909FFE8422F4C02AAC07 /* CoreFoundation.framework */; };
@@ -37,6 +42,11 @@
 		08FB77B6FE84183AC02AAC07 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
 		0AA1909FFE8422F4C02AAC07 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = /System/Library/Frameworks/CoreFoundation.framework; sourceTree = "<absolute>"; };
 		2C05A19B06CAA52B00D84F6F /* GeneratePreviewForURL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratePreviewForURL.m; sourceTree = "<group>"; };
+		4F98DDDD156E04F500C17A7F /* URLChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = URLChecker.h; sourceTree = "<group>"; };
+		4F98DDDE156E04F500C17A7F /* URLChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = URLChecker.m; sourceTree = "<group>"; };
+		4F98DDE2156E0C9F00C17A7F /* QLStephenWhiteList.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = QLStephenWhiteList.plist; sourceTree = "<group>"; };
+		4F98DDE4156E0CB500C17A7F /* QLStephenExtensionsBlackList.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = QLStephenExtensionsBlackList.plist; sourceTree = "<group>"; };
+		4F98DDE6156E0F0A00C17A7F /* QLStephenDirectoriesBlackList.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = QLStephenDirectoriesBlackList.plist; sourceTree = "<group>"; };
 		61E3BCFA0870B4F2002186A0 /* GenerateThumbnailForURL.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = GenerateThumbnailForURL.m; sourceTree = "<group>"; };
 		8D576316048677EA00EA77CD /* QLStephen.qlgenerator */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QLStephen.qlgenerator; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D576317048677EA00EA77CD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -99,6 +109,11 @@
 			children = (
 				61E3BCFA0870B4F2002186A0 /* GenerateThumbnailForURL.m */,
 				2C05A19B06CAA52B00D84F6F /* GeneratePreviewForURL.m */,
+				4F98DDDD156E04F500C17A7F /* URLChecker.h */,
+				4F98DDDE156E04F500C17A7F /* URLChecker.m */,
+				4F98DDE2156E0C9F00C17A7F /* QLStephenWhiteList.plist */,
+				4F98DDE4156E0CB500C17A7F /* QLStephenExtensionsBlackList.plist */,
+				4F98DDE6156E0F0A00C17A7F /* QLStephenDirectoriesBlackList.plist */,
 				08FB77B6FE84183AC02AAC07 /* main.c */,
 			);
 			name = Source;
@@ -119,6 +134,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4F98DDDF156E04F500C17A7F /* URLChecker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,6 +192,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				8D5B49A804867FD3000E48DA /* InfoPlist.strings in Resources */,
+				4F98DDE3156E0C9F00C17A7F /* QLStephenWhiteList.plist in Resources */,
+				4F98DDE5156E0CB500C17A7F /* QLStephenExtensionsBlackList.plist in Resources */,
+				4F98DDE7156E0F0A00C17A7F /* QLStephenDirectoriesBlackList.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -199,6 +218,7 @@
 				8D576312048677EA00EA77CD /* main.c in Sources */,
 				2C05A19C06CAA52B00D84F6F /* GeneratePreviewForURL.m in Sources */,
 				61E3BCFB0870B4F2002186A0 /* GenerateThumbnailForURL.m in Sources */,
+				4F98DDE0156E04F500C17A7F /* URLChecker.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/QuickLookStephenProject/URLChecker.h
+++ b/QuickLookStephenProject/URLChecker.h
@@ -1,0 +1,11 @@
+//
+//  URLChecker.h
+//  QuickLookStephen
+//
+//  Created by Guillermo Enriquez on 5/24/12.
+//  Copyright (c) 2012 nacho4d. All rights reserved.
+//
+
+#import <CoreFoundation/CoreFoundation.h>
+
+bool shouldProcessItem(CFURLRef itemURL, CFBundleRef bundle);

--- a/QuickLookStephenProject/URLChecker.m
+++ b/QuickLookStephenProject/URLChecker.m
@@ -1,0 +1,48 @@
+//
+//  URLChecker
+//  QuickLookStephen
+//
+//  Created by Guillermo Enriquez on 5/24/12.
+//  Copyright (c) 2012 nacho4d. All rights reserved.
+//
+
+#import "URLChecker.h"
+#import <Foundation/Foundation.h>
+
+bool shouldProcessItem(CFURLRef itemURL, CFBundleRef bundle)
+{
+	NSURL *url = (NSURL *)itemURL;
+
+	// Allow these files always, no matter what
+	NSURL *whiteListURL = (NSURL *)CFBundleCopyResourceURL(bundle, CFSTR("QLStephenWhiteList"), CFSTR("plist"), NULL);
+	NSArray *whiteList = [NSArray arrayWithContentsOfURL:whiteListURL];
+	[whiteListURL release];
+	if ([whiteList containsObject:[url lastPathComponent]]) {
+		return true;
+	}
+
+	NSString *extension = [url pathExtension];
+
+	// Filter file with certain extensions
+	NSURL *extBlackListURL = (NSURL *)CFBundleCopyResourceURL(bundle, CFSTR("QLStephenExtensionsBlackList"), CFSTR("plist"), NULL);
+	NSArray *extBlackList = [NSArray arrayWithContentsOfURL:extBlackListURL];
+	[extBlackListURL release];
+	if ([extBlackList containsObject:extension]) {
+		return false;
+	}
+
+	// Filter files inside folders with certain names
+	NSArray *components = [[url path] pathComponents];
+	if (components.count > 1) {
+		NSURL *dirBlackListURL = (NSURL *)CFBundleCopyResourceURL(bundle, CFSTR("QLStephenDirectoriesBlackList"), CFSTR("plist"), NULL);
+		NSArray *dirBlackList = [NSArray arrayWithContentsOfURL:dirBlackListURL];
+		[dirBlackListURL release];
+		NSString *folder = [components objectAtIndex:components.count - 2];
+		if ([dirBlackList containsObject:folder]) {
+			return false;
+		}
+	}
+
+	// For all other files do it!
+	return true;
+}


### PR DESCRIPTION
I just added a function `bool shouldProcessItem(CFURLRef, CFBundleRef)`
that will return true when the file should be previewed. Preventing certain files from being previewed (e.g.: binary files like zip, tar, lib, a, o, etc, commands, etc)

The function is in a separate file because if at some point you decide to implement the thumbnail generation functions I thought it will be easier to use this way.

[In first place](https://github.com/whomwah/qlstephen/issues/1) I though of using NSUserDefaults but realized that it would be a pain to simply add values so I came up with plists and there are 3 of them:

**QLStephenWhiteList.plist** : files with these names will be ALWAYS previewed
**QLStephenExtensionsBlackList.plist** : files with these extensions will NOT be previewed
**QLStephenDirectoriesBlackList.plist** : files contained in directories with these names will NOT be previewed

Everyone has its own needs so they are free to modify the plists as they need :) Works great for me.
