### PR TITLE
Fix #49 using a file with LC_ALL=C as fallback

### DIFF
--- a/QuickLookStephenProject/QLSFileAttributes.m
+++ b/QuickLookStephenProject/QLSFileAttributes.m
@@ -24,7 +24,8 @@
     return nil;
   }
 
-  NSString *magicString = [self magicStringForItemAtURL:aURL];
+  NSString *magicString = [self magicStringForItemAtURL:aURL usingLcALL:@"en_US.UTF-8"];
+  if (!magicString) magicString = [self magicStringForItemAtURL:aURL usingLcALL:@"C"];
   if (!magicString) return nil;
   NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"(\\S+/\\S+); charset=(\\S+)" options:0 error:nil];
   NSTextCheckingResult *match = [regex firstMatchInString:magicString options:0 range:NSMakeRange(0, magicString.length)];
@@ -52,13 +53,13 @@
 // Private Methods
 ////////////////////////////////////////////////////////////////////////////////
 
-+ (NSString *)magicStringForItemAtURL:(NSURL *)aURL {
++ (NSString *)magicStringForItemAtURL:(NSURL *)aURL usingLcALL:(NSString *)lcALL {
   NSString *path = [aURL path];
   NSParameterAssert(path);
 
   NSMutableDictionary *environment =
       [NSProcessInfo.processInfo.environment mutableCopy];
-  environment[@"LC_ALL"] = @"en_US.UTF-8";
+  environment[@"LC_ALL"] = lcALL;
 
   NSTask *task = [NSTask new];
   task.launchPath = @"/usr/bin/file";


### PR DESCRIPTION
came across the same problem as in issue #49 

noticed that /usr/bin/file crashes, when trying to determine the content type

```
$ file /tmp/test
/tmp/test: ERROR: line 22: regexec error 17, (illegal byte sequence)
```

by changing the environment variable LC_ALL to C, it works as expected
```
LC_ALL=C file /tmp/test
/tmp/test: UTF-8 Unicode text
```

this PR changes the behavior on running file, by trying to run file again with `LC_ALL=C` if the first run using `LC_ALL=en_US.utf8` failed