### PR TITLE
Allow to configure font settings for preview

### DIFF
--- a/QuickLookStephenProject/GeneratePreviewForURL.m
+++ b/QuickLookStephenProject/GeneratePreviewForURL.m
@@ -7,6 +7,24 @@
 #import "QLSFileAttributes.h"
 
 #define DEFAULT_MAX_FILE_SIZE 1024 * 100
+#define DEFAULT_FONT_SIZE "11px"
+#define DEFAULT_LINE_HEIGHT "20px"
+#define DEFAULT_FONT_FAMILY "Monaco"
+#define QUOTE(...) #__VA_ARGS__
+NSString *const kHTMLTemplate = @QUOTE(
+  <html>
+  <head>
+    <title>%@</title>
+    <style>
+      body {
+        font: normal normal %@/%@ '%@', monospace;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>%@</body>
+  </html>
+);
 
 // Generate a preview for the document with the given url
 OSStatus GeneratePreviewForURL(void *thisInterface,
@@ -38,7 +56,8 @@ OSStatus GeneratePreviewForURL(void *thisInterface,
     NSDictionary *previewProperties = @{
       (NSString *)kQLPreviewPropertyStringEncodingKey : @( magicAttributes.fileEncoding ),
       (NSString *)kQLPreviewPropertyWidthKey      : @700,
-      (NSString *)kQLPreviewPropertyHeightKey     : @800
+      (NSString *)kQLPreviewPropertyHeightKey     : @800,
+      (NSString *)kQLPreviewPropertyMIMETypeKey   : @"text/html",
     };
 
     // Get size of current File
@@ -56,28 +75,56 @@ OSStatus GeneratePreviewForURL(void *thisInterface,
     if(maxFileSizeSetting > 0) {
       maxFileSize = maxFileSizeSetting;
     }
-
+    
+    NSString *body;
+    
     // Display less data, if file is too big
     if(attrs.fileSize > maxFileSize) {
       NSFileHandle *myFile= [NSFileHandle fileHandleForReadingAtPath:[file_url path]];
       if(!myFile) {
         return noErr;
       }
-      NSData *displayData = [myFile readDataOfLength:maxFileSize];
-      [myFile closeFile];
 
-      QLPreviewRequestSetDataRepresentation(
-          request,
-          (__bridge CFDataRef)displayData,
-          kUTTypePlainText,
-          (__bridge CFDictionaryRef)previewProperties);
-      return noErr;
+      NSData *bodyData = [myFile readDataOfLength:maxFileSize];
+      [myFile closeFile];
+      body = [NSString stringWithUTF8String:[bodyData bytes]];
+    } else {
+      NSError *error;
+      body = [[NSString alloc] initWithContentsOfURL:file_url
+                                            encoding:magicAttributes.fileEncoding
+                                               error:&error];
+      
+      if (body == nil) {
+        NSLog(@"Error reading file at %@\n%@", file_url, [error localizedFailureReason]);
+        return noErr;
+      }
     }
-    QLPreviewRequestSetURLRepresentation(
-        request,
-        url,
-        kUTTypePlainText,
-        (__bridge CFDictionaryRef)previewProperties);
+    
+    NSString *fontSize = defaults[@"fontSize"];
+    if (fontSize == nil) {
+      fontSize = @DEFAULT_FONT_SIZE;
+    }
+    NSString *lineHeight = defaults[@"lineHeight"];
+    if (lineHeight == nil) {
+      lineHeight = @DEFAULT_LINE_HEIGHT;
+    }
+    NSString *fontFamily = defaults[@"fontFamily"];
+    if (fontFamily == nil) {
+      fontFamily = @DEFAULT_FONT_FAMILY;
+    }
+
+
+    NSString *html = [NSString stringWithFormat: kHTMLTemplate,
+                      [file_url lastPathComponent],
+                      fontSize,
+                      lineHeight,
+                      fontFamily,
+                      body];
+    
+    QLPreviewRequestSetDataRepresentation(request,
+                                          (__bridge CFDataRef) [html dataUsingEncoding: NSUTF8StringEncoding],
+                                          kUTTypeHTML,
+                                          (__bridge CFDictionaryRef) previewProperties);
 
     return noErr;
   }


### PR DESCRIPTION
This PR changes preview type to kUITypeHTML and adds keys to user defaults: fontFamily, fontSize, lineHeight.
It solves issue #31

Configuration examples:

```sh
$ defaults write com.whomwah.quicklookstephen fontFamily "InputMono-Regular"
$ defaults write com.whomwah.quicklookstephen fontSize "13px"
$ defaults write com.whomwah.quicklookstephen lineHeight "21px"
```