### PR TITLE
Update Info.plist

### DIFF
--- a/QuickLookStephenProject/Info.plist
+++ b/QuickLookStephenProject/Info.plist
@@ -13,7 +13,35 @@
 			<string>QLGenerator</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>public.data</string>
+				<string>public.unix-executable</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+			<key>NSPersistentStoreTypeKey</key>
+			<string>XML</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>com.apple.xcode.strings-text</string>
+			<key>CFBundleTypeRole</key>
+			<string>QLGenerator</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.apple.xcode.strings-text</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+			<key>NSPersistentStoreTypeKey</key>
+			<string>XML</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>public.unix-executable</string>
+			<key>CFBundleTypeRole</key>
+			<string>QLGenerator</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.unix-executable</string>
 			</array>
 			<key>LSTypeIsPackage</key>
 			<false/>
@@ -32,9 +60,9 @@
 	<key>CFBundleName</key>
 	<string>QLStephen</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.44</string>
+	<string>1.45</string>
 	<key>CFBundleVersion</key>
-	<string>1.4.4</string>
+	<string>1.4.5</string>
 	<key>CFPlugInDynamicRegisterFunction</key>
 	<string></string>
 	<key>CFPlugInDynamicRegistration</key>


### PR DESCRIPTION
- add two new type to allow displaying .string files and README and LICENSE files since OS X sometime report them as public.unix-executable

- Testing instructions:

// Testing.
//
// Reload them after install in /Libary/QuickLook/ or ~/Libary/QuickLook/ :
// qlmanage -r
//
// Test them with -d4 to see debug information such as mime types and quicklook installed.
// ie.
// qlmanage -p -d4 /Users/markf/Downloads/quicklook\ plugins/qlstephen-1.4.4/LICENSE