### PR TITLE
Add support for extension-less shell scripts

### DIFF
--- a/QuickLookStephenProject/Info.plist
+++ b/QuickLookStephenProject/Info.plist
@@ -15,6 +15,7 @@
 			<array>
 				<string>public.data</string>
 				<string>public.content</string>
+				<string>public.unix-executable</string>
 			</array>
 			<key>LSTypeIsPackage</key>
 			<false/>


### PR DESCRIPTION
If we want it.
Adding `public.unix-executable` to the list of data types will allow us to inspect shell scripts that have no extension. For the few exectuables I have tested that were not human readable, QL displayed the "exec"-Icon instead (accordingly). Have not tested a lot of executables though…