### PR TITLE
Patch 1

### DIFF
--- a/QuickLookStephenProject/GeneratePreviewForURL.m
+++ b/QuickLookStephenProject/GeneratePreviewForURL.m
@@ -22,7 +22,10 @@ OSStatus GeneratePreviewForURL(void *thisInterface,
         [QLSFileAttributes attributesForItemAtURL:(__bridge NSURL *)url];
 
     if (!magicAttributes) {
-      NSLog(@"QLStephen: Could not determine attribtues of file %@", url);
+      // if the URL is for a .DS_Store file, don't bother with logging call
+      if (![[(__bridge NSURL *)url lastPathComponent] isEqualToString:@".DS_Store"]) {
+        NSLog(@"QLStephen: Could not determine attributes of file %@", [(__bridge NSURL *)url path]);
+      }
       return noErr;
     }
 
@@ -31,7 +34,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface,
     }
 
     if (magicAttributes.fileEncoding == kCFStringEncodingInvalidId) {
-      NSLog(@"QLStephen: Could not determine encoding of file %@", url);
+      NSLog(@"QLStephen: Could not determine encoding of file %@", [(__bridge NSURL *)url path]);
       return noErr;
     }
 

--- a/QuickLookStephenProject/GenerateThumbnailForURL.m
+++ b/QuickLookStephenProject/GenerateThumbnailForURL.m
@@ -121,7 +121,10 @@ OSStatus GenerateThumbnailForURL(void *thisInterface,
         = [QLSFileAttributes attributesForItemAtURL:(__bridge NSURL *)url];
 
     if (!magicAttributes) {
-      NSLog(@"QLStephen: Could not determine attribtues of file %@", url);
+      // if the URL is for a .DS_Store file, don't bother with logging call
+      if (![[(__bridge NSURL *)url lastPathComponent] isEqualToString:@".DS_Store"]) {
+        NSLog(@"QLStephen: Could not determine attributes of file %@", [(__bridge NSURL *)url path]);
+      }
       return noErr;
     }
 
@@ -131,7 +134,7 @@ OSStatus GenerateThumbnailForURL(void *thisInterface,
     }
 
     if (magicAttributes.fileEncoding == kCFStringEncodingInvalidId) {
-      NSLog(@"QLStephen: Could not determine encoding of file %@", url);
+      NSLog(@"QLStephen: Could not determine encoding of file %@", [(__bridge NSURL *)url path]);
       return noErr;
     }
 

--- a/QuickLookStephenProject/GenerateThumbnailForURL.m
+++ b/QuickLookStephenProject/GenerateThumbnailForURL.m
@@ -44,7 +44,7 @@ static NSString *ThumbnailBadgeForItemWithAttributes(
 
   // Do we have a file extension? If so, use it as a badge if it's not too
   // long.
-  if (![fileExtension isEqualToString:@""]) {
+  if (fileExtension.length) {
     badge = fileExtension;
 
     // Is the file extension too long to be reasonably displayed in a
@@ -62,13 +62,13 @@ static NSString *ThumbnailBadgeForItemWithAttributes(
   // have no file extension. file(1) might wrongly guess the MIME type, and it
   // would be annoying if the file extension were to say one thing and the
   // badge another.
-  if (!badge && [fileExtension isEqualToString:@""]) {
+  if (!badge && fileExtension.length == 0) {
     NSDictionary *map = mimeTypeToBadgeMap();
     badge = map[attributes.mimeType];
   }
   
   // Does the filename match a known pattern? If so, use the appropriate badge.
-  if (!badge && [fileExtension isEqualToString:@""]) {
+  if (!badge && fileExtension.length == 0) {
     NSDictionary *map = filenameRegexToBadgeMap();
     [map enumerateKeysAndObjectsUsingBlock:
       ^(NSString *pattern, NSString *candidateBadge, BOOL *stop) {

--- a/QuickLookStephenProject/QuickLookStephen.xcodeproj/project.pbxproj
+++ b/QuickLookStephenProject/QuickLookStephen.xcodeproj/project.pbxproj
@@ -25,16 +25,16 @@
 		0107ABFD15C76F2900C65F1A /* QLSFileAttributes.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = QLSFileAttributes.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		0149EB3D15F2E9A3003AB298 /* libicucore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicucore.dylib; path = usr/lib/libicucore.dylib; sourceTree = SDKROOT; };
 		08FB77B6FE84183AC02AAC07 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
-		0AA1909FFE8422F4C02AAC07 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = /System/Library/Frameworks/CoreFoundation.framework; sourceTree = "<absolute>"; };
 		2C05A19B06CAA52B00D84F6F /* GeneratePreviewForURL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratePreviewForURL.m; sourceTree = "<group>"; usesTabs = 0; };
+		0AA1909FFE8422F4C02AAC07 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		3B177A13234CD36D00AA1345 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		61E3BCFA0870B4F2002186A0 /* GenerateThumbnailForURL.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = GenerateThumbnailForURL.m; sourceTree = "<group>"; };
 		8D576316048677EA00EA77CD /* QLStephen.qlgenerator */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QLStephen.qlgenerator; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D576317048677EA00EA77CD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		AE02F6EA0EDDFA6400CBA17D /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
-		C86B05260671AA6E00DD9006 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = /System/Library/Frameworks/CoreServices.framework; sourceTree = "<absolute>"; };
-		F28CFBFC0A3EC0AF000ABFF5 /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = /System/Library/Frameworks/ApplicationServices.framework; sourceTree = "<absolute>"; };
-		F28CFC020A3EC0C6000ABFF5 /* QuickLook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLook.framework; path = /System/Library/Frameworks/QuickLook.framework; sourceTree = "<absolute>"; };
+		AE02F6EA0EDDFA6400CBA17D /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		C86B05260671AA6E00DD9006 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
+		F28CFBFC0A3EC0AF000ABFF5 /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = System/Library/Frameworks/ApplicationServices.framework; sourceTree = SDKROOT; };
+		F28CFC020A3EC0C6000ABFF5 /* QuickLook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLook.framework; path = System/Library/Frameworks/QuickLook.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/QuickLookStephenProject/QuickLookStephen.xcodeproj/project.pbxproj
+++ b/QuickLookStephenProject/QuickLookStephen.xcodeproj/project.pbxproj
@@ -12,10 +12,8 @@
 		2C05A19C06CAA52B00D84F6F /* GeneratePreviewForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C05A19B06CAA52B00D84F6F /* GeneratePreviewForURL.m */; };
 		61E3BCFB0870B4F2002186A0 /* GenerateThumbnailForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E3BCFA0870B4F2002186A0 /* GenerateThumbnailForURL.m */; };
 		8D576312048677EA00EA77CD /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 08FB77B6FE84183AC02AAC07 /* main.c */; settings = {ATTRIBUTES = (); }; };
-		8D576314048677EA00EA77CD /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AA1909FFE8422F4C02AAC07 /* CoreFoundation.framework */; };
 		8D5B49A804867FD3000E48DA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8D5B49A704867FD3000E48DA /* InfoPlist.strings */; };
 		AE02F6EB0EDDFA6400CBA17D /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE02F6EA0EDDFA6400CBA17D /* Cocoa.framework */; };
-		C86B05270671AA6E00DD9006 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C86B05260671AA6E00DD9006 /* CoreServices.framework */; };
 		F28CFBFD0A3EC0AF000ABFF5 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F28CFBFC0A3EC0AF000ABFF5 /* ApplicationServices.framework */; };
 		F28CFC030A3EC0C6000ABFF5 /* QuickLook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F28CFC020A3EC0C6000ABFF5 /* QuickLook.framework */; };
 /* End PBXBuildFile section */
@@ -43,8 +41,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0149EB3E15F2E9A3003AB298 /* libicucore.dylib in Frameworks */,
-				8D576314048677EA00EA77CD /* CoreFoundation.framework in Frameworks */,
-				C86B05270671AA6E00DD9006 /* CoreServices.framework in Frameworks */,
 				F28CFBFD0A3EC0AF000ABFF5 /* ApplicationServices.framework in Frameworks */,
 				F28CFC030A3EC0C6000ABFF5 /* QuickLook.framework in Frameworks */,
 				AE02F6EB0EDDFA6400CBA17D /* Cocoa.framework in Frameworks */,


### PR DESCRIPTION
Switched from absolute to relative-to-SDK framework paths. Also fixed a few typos and prevented logging calls (e.g. "Could not determine attributes of file ...") when encountering .DS_Store files.