### PR TITLE
Fix `make install` when ~/Library/QuickLook doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ debug:
 install:
 	@if [ -d  "./build/Release/QLStephen.qlgenerator" ]; then \
 		rm -rf ~/Library/QuickLook/QLStephen.qlgenerator ; \
+		mkdir -p ~/Library/QuickLook ; \
 		cp -r ./build/Release/QLStephen.qlgenerator ~/Library/QuickLook/ ; \
 		qlmanage -r ; \
 	else \


### PR DESCRIPTION
On a clean install of macOS Big Sur, there is no ~/Library/QuickLook
folder, which breaks the `cp` command in the `install` target. Fix
this by ensuring that ~/Library/QuickLook exists.