### PR TITLE
Brew Casks can't be installed with `brew cask install` anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ QLStephen is a QuickLook plugin that lets you view text files without their own 
 
 ### Homebrew
 
-    brew cask install qlstephen
+    brew install --cask qlstephen
 
 ### Pre-compiled
 


### PR DESCRIPTION
For some month now, casks can not be installed with `brew cask install ...` anymore. Instead you have to use `brew install --cask ...`.
See the docs: https://docs.brew.sh/Manpage#install-options-formulacask-