### PR TITLE
Update Homebrew now that 'cask' is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ QLStephen is a QuickLook plugin that lets you view text files without their own 
 
 ### Homebrew
 
-    brew cask install qlstephen
+    brew install qlstephen
 
 ### Pre-compiled
 


### PR DESCRIPTION
See https://brew.sh/2020/12/01/homebrew-2.6.0/

tl;dr 'cask' should be removed from installation commands.