### PR TITLE
Update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ QLStephen is a QuickLook plugin that lets you view text files without their own 
 
 ### Homebrew
 
-    brew cask install qlstephen
+    brew install --cask qlstephen
 
 ### Pre-compiled
 


### PR DESCRIPTION
Update command as shown at https://formulae.brew.sh/cask/qlstephen#default.

`brew cask install qlstephen` fails with `Error: Unknown command: cask` in brew 3.3.9.