### PR TITLE
the fix for known/unknown child UTIs to be handled by QLStephen, resolves #87

### DIFF
--- a/QuickLookStephenProject/QuickLookStephen.xcodeproj/project.pbxproj
+++ b/QuickLookStephenProject/QuickLookStephen.xcodeproj/project.pbxproj
@@ -201,7 +201,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				INFOPLIST_FILE = Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = com.whomwah.quicklookstephen;
+				PRODUCT_BUNDLE_IDENTIFIER = com.apple.quicklookstephen;
 				PRODUCT_NAME = QLStephen;
 				USER_HEADER_SEARCH_PATHS = No;
 				USE_HEADERMAP = NO;
@@ -219,7 +219,7 @@
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				INFOPLIST_FILE = Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = com.whomwah.quicklookstephen;
+				PRODUCT_BUNDLE_IDENTIFIER = com.apple.quicklookstephen;
 				PRODUCT_NAME = QLStephen;
 				USER_HEADER_SEARCH_PATHS = No;
 				USE_HEADERMAP = NO;


### PR DESCRIPTION
So cheaply pretending to be a QLGenerator from Apple seems to be the way to make Quick Look use QLStephen also for UTIs with direct, indirect, explicit and implicit (for dynamic UTIs) conformance to UTI registered for it.

If this is the fix, I can only remember that most used language in programming is profanity.